### PR TITLE
XIP-32 submission

### DIFF
--- a/XIP-32 submission
+++ b/XIP-32 submission
@@ -1,0 +1,18 @@
+The following tweet from Infinex official X account suggests to
+
+https://x.com/infinex_app/status/1796693183642149094
+ 
+Vote for who should receive a share of 30M GP from the 'GP Retirement Fund
+
+Now, how about to make such a vote just available to:
+
+a) NFT holders of mentioned communities
+
+b) Infinex community members
+
+I'd suggest to enable the vote within Infinex Discord, which would tick both of the above criteria and also incentivise 1 vote per 1 person, instead of 1 vote per wallet holding the NFTs (holders could distribute to multiple wallets)
+
+To identify holders, Discord bots have to be added:
+
+-Guild or Collabland for EVM
+-Matrica Verification for Solana


### PR DESCRIPTION
The following tweet from Infinex official X account suggests to

https://x.com/infinex_app/status/1796693183642149094
 
Vote for who should receive a share of 30M GP from the 'GP Retirement Fund

Now, how about to make such a vote just available to:

a) NFT holders of mentioned communities

b) Infinex community members

I'd suggest to enable the vote within Infinex Discord, which would tick both of the above criteria and also incentivise 1 vote per 1 person, instead of 1 vote per wallet holding the NFTs (holders could distribute to multiple wallets)

To identify holders, Discord bots have to be added:

-Guild or Collabland for EVM
-Matrica Verification for Solana